### PR TITLE
fix: prevent app from crashing after upgrading Python base image

### DIFF
--- a/thumbnailer/Dockerfile
+++ b/thumbnailer/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.11.1
 
-RUN pip install flask
+RUN pip install flask waitress
 
 COPY webapp.py webapp.py
 COPY templates templates

--- a/thumbnailer/webapp.py
+++ b/thumbnailer/webapp.py
@@ -25,4 +25,5 @@ def upload():
     return response
 
 if __name__ == '__main__':
-    app.run(debug=True,host='0.0.0.0')
+    from waitress import serve
+    serve(app, host="0.0.0.0", port=5000)


### PR DESCRIPTION
For some unknown reason, after upgrading the base image to `3.13.0a4`, the app crashes when it's accessed. We found this in the logs:
```
WSParticipantRole:~/environment/goof/thumbnailer (develop) $ k logs thumbnailer-58cfc668c5-zfzkz 
 * Serving Flask app 'webapp'
 * Debug mode: on
WARNING: This is a development server. Do not use it in a production deployment. Use a production WSGI server instead.
 * Running on all addresses (0.0.0.0)
 * Running on http://127.0.0.1:5000/
 * Running on http://10.42.121.176:5000/
Press CTRL+C to quit
 * Restarting with stat
 * Debugger is active!
 * Debugger PIN: 799-586-819
 ```

At first we looked into `Restarting with stat`, but it's a red herring. The big `WARNING` seems to be what's causing it, as the built-in server crashes when `/` is accessed 🤦 

To remediate this, we switched to `waitress`, "a production-quality pure-Python WSGI server with very acceptable performance." No more crashing after the switch 🙌 

cc @shivamjindalsnyk @ericsmalling