### PR TITLE
Add 'envsubst' to setup script

### DIFF
--- a/cloudWorkstations-setup/setup.sh
+++ b/cloudWorkstations-setup/setup.sh
@@ -7,10 +7,12 @@ function command_exists() {
   command -v "$1" >/dev/null 2>&1
 }
 
-# Check if gcloud is installed
-if ! command_exists "gcloud"; then
-  echo "Error: gcloud is not installed. Please install gcloud and try again."
-  exit 1
+# Check if envsubst is installed
+if ! command_exists "envsubst"; then
+  echo "Installing envsubst..."
+  sudo apt-get update
+  sudo apt-get install gettext
+  echo "envsubst installed."
 fi
 
 # Check if a region argument is provided


### PR DESCRIPTION
The workshop includes the following command:
`cat manifests/*.yaml | envsubst | kubectl apply -f -`

We need to install `envsubst` for this command to work.

cc: @jackryan-snyk @mnichols-snyk 